### PR TITLE
Chore: Cleanup

### DIFF
--- a/EdgeDB.Tests.Benchmarks/Program.cs
+++ b/EdgeDB.Tests.Benchmarks/Program.cs
@@ -26,14 +26,14 @@ public class Benchmarks
 
     // benchmark our default client as overhead
     [Benchmark]
-    public async Task BenchmarkQueryOverhead()
+    public static async Task BenchmarkQueryOverhead()
     {
         await SingleClient.QueryAsync<string>("select \"Hello, World!\"").ConfigureAwait(false);
     }
 
     // define our main benchmark
     [Benchmark]
-    public async Task BenchmarkQuery()
+    public static async Task BenchmarkQuery()
     {
         await ClientPool!.QueryAsync<string>("select \"Hello, World!\"").ConfigureAwait(false);
     }

--- a/examples/EdgeDB.ExampleApp/Examples/IExample.cs
+++ b/examples/EdgeDB.ExampleApp/Examples/IExample.cs
@@ -11,7 +11,7 @@ namespace EdgeDB.ExampleApp
 
         static async Task ExecuteAllAsync(EdgeDBClient client, ILogger logger)
         {
-            var examples = Assembly.GetExecutingAssembly().GetTypes().Where(x => x.IsAssignableTo(typeof(IExample)) && x != typeof(IExample));
+            var examples = typeof(IExample).Assembly.GetTypes().Where(x => x.IsAssignableTo(typeof(IExample)) && x != typeof(IExample));
 
             foreach (var example in examples)
             {

--- a/examples/EdgeDB.ExampleApp/Logger.cs
+++ b/examples/EdgeDB.ExampleApp/Logger.cs
@@ -56,20 +56,28 @@ namespace EdgeDB.ExampleApp
         };
         public void Trace(string content, LogPostfix postfix = LogPostfix.Log, Exception? exception = null, bool stdErr = false)
             => Write(content, exception, stdErr, postfix, LogPostfix.Trace);
+
         public void Log(string content, LogPostfix postfix = LogPostfix.Log, Exception? exception = null, bool stdErr = false)
             => Write(content, exception, stdErr, postfix, LogPostfix.Log);
+
         public void Warn(string content, LogPostfix postfix = LogPostfix.Log, Exception? exception = null, bool stdErr = false)
             => Write(content, exception, stdErr, postfix, LogPostfix.Warning);
+
         public void Error(string content, LogPostfix postfix = LogPostfix.Log, Exception? exception = null, bool stdErr = false)
             => Write(content, exception, stdErr, postfix, LogPostfix.Error);
+
         public void Critical(string content, LogPostfix postfix = LogPostfix.Log, Exception? exception = null, bool stdErr = false)
             => Write(content, exception, stdErr, postfix, LogPostfix.Critical);
+
         public void Debug(string content, LogPostfix postfix = LogPostfix.Log, Exception? exception = null, bool stdErr = false)
             => Write(content, exception, stdErr, postfix, LogPostfix.Debug);
+
         public void Info(string content, LogPostfix postfix = LogPostfix.Log, Exception? exception = null, bool stdErr = false)
             => Write(content, exception, stdErr, postfix, LogPostfix.Info);
+
         public void Write(string conent, Exception? exception, bool stdErr = false, params LogPostfix[] postfix)
             => Write(conent, postfix, exception, stdErr);
+
         public void Write(string content, IEnumerable<LogPostfix> postfix, Exception? exception = null, bool stdErr = false)
         {
             if (_postFixs.Length > 0 && !_postFixs.Contains(postfix.First()))
@@ -145,12 +153,15 @@ namespace EdgeDB.ExampleApp
 
         public static Logger GetLogger<TType>(params LogPostfix[] postfixs)
             => GetLogger(typeof(TType), postfixs);
+
         public static Logger GetLogger(Type t, params LogPostfix[] postfixs)
             => new($"{t.Assembly.GetName().Name}:{t.Name}", postfixs);
 
-        public static void AddStream(Stream stream, StreamType type) => _streams.Add((type, stream));
+        public static void AddStream(Stream stream, StreamType type) 
+            => _streams.Add((type, stream));
 
-        public static void RegisterCommand(string commandName, Func<string, Task> commandResult) => _commands.TryAdd(commandName, commandResult);
+        public static void RegisterCommand(string commandName, Func<string, Task> commandResult) 
+            => _commands.TryAdd(commandName, commandResult);
 
         private LogMessage CreateLogMessage(IEnumerable<LogPostfix> severities, string message, StreamType type)
         {
@@ -224,6 +235,7 @@ namespace EdgeDB.ExampleApp
 
             return returnData;
         }
+
         private static ConsoleColor? GetColor(string tag)
         {
             return Enum.TryParse(typeof(ConsoleColor), tag, true, out var res)
@@ -262,12 +274,15 @@ namespace EdgeDB.ExampleApp
 
         public static string BuildColoredString(object? s, ConsoleColor color)
             => BuildColoredString(s?.ToString(), color);
-        public static string BuildColoredString(string? s, ConsoleColor color) => $"<{color}>{s}</{color}>";
+
+        public static string BuildColoredString(string? s, ConsoleColor color) 
+            => $"<{color}>{s}</{color}>";
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
-            if (state == null)
+            if (state is null)
                 return;
+
             var lvl = logLevel switch
             {
                 LogLevel.Debug => LogPostfix.Debug,
@@ -283,18 +298,18 @@ namespace EdgeDB.ExampleApp
             Write(state.ToString()!, exception, postfix: lvl);
         }
 
-        public bool IsEnabled(LogLevel logLevel) => true;
+        public bool IsEnabled(LogLevel logLevel) 
+            => true;
 
-        public IDisposable BeginScope<TState>(TState state) =>
-#pragma warning disable CS8603 // Possible null reference return.
-            null;
-#pragma warning restore CS8603 // Possible null reference return.
-
+        public IDisposable BeginScope<TState>(TState state) 
+            => null!;
 
         private struct LogMessage
         {
             public string Caller { get; set; }
+
             public string Content { get; set; }
+
             public StreamType Type { get; set; }
         }
     }

--- a/src/EdgeDB.Net.Driver/ClientPacketDuplexer.cs
+++ b/src/EdgeDB.Net.Driver/ClientPacketDuplexer.cs
@@ -127,10 +127,8 @@ namespace EdgeDB
             using var ms = new MemoryStream();
             foreach (var packet in packets)
             {
-                using (var writer = new PacketWriter(ms))
-                {
-                    packet.Write(writer, _client);
-                }
+                using var writer = new PacketWriter(ms);
+                packet.Write(writer, _client);
             }
 
             await _stream.WriteAsync(ms.ToArray(), linkedToken.Token).ConfigureAwait(false);

--- a/src/EdgeDB.Net.Driver/Clients/BaseEdgeDBClient.cs
+++ b/src/EdgeDB.Net.Driver/Clients/BaseEdgeDBClient.cs
@@ -11,13 +11,13 @@
             ClientId = clientId;
         }
 
+        private readonly AsyncEvent<Func<BaseEdgeDBClient, ValueTask<bool>>> _onDisposed = new();
+
         internal event Func<BaseEdgeDBClient, ValueTask<bool>> OnDisposed
         {
             add => _onDisposed.Add(value);
             remove => _onDisposed.Remove(value);
         }
-        private AsyncEvent<Func<BaseEdgeDBClient, ValueTask<bool>>> _onDisposed = new ();
-
 
         public virtual async ValueTask<bool> DisposeAsync()
         {
@@ -33,10 +33,15 @@
         }
 
         public abstract ValueTask DisconnectAsync();
+
         public abstract ValueTask ConnectAsync();
+
         public abstract Task ExecuteAsync(string query, IDictionary<string, object?>? args = null);
+
         public abstract Task<IReadOnlyCollection<TResult?>> QueryAsync<TResult>(string query, IDictionary<string, object?>? args = null);
+
         public abstract Task<TResult> QueryRequiredSingleAsync<TResult>(string query, IDictionary<string, object?>? args = null);
+
         public abstract Task<TResult?> QuerySingleAsync<TResult>(string query, IDictionary<string, object?>? args = null);
 
         async ValueTask IAsyncDisposable.DisposeAsync() 

--- a/src/EdgeDB.Net.Driver/Clients/EdgeDBHttpClient.cs
+++ b/src/EdgeDB.Net.Driver/Clients/EdgeDBHttpClient.cs
@@ -25,23 +25,31 @@ namespace EdgeDB
         {
             [JsonProperty("message")]
             public string? Message { get; set; }
+
             [JsonProperty("type")]
             public string? Type { get; set; }
+
             [JsonProperty("code")]
             public uint Code { get; set; }
 
-            string? IExecuteError.Message => Message;
+            string? IExecuteError.Message 
+                => Message;
 
-            uint IExecuteError.ErrorCode => Code;
+            uint IExecuteError.ErrorCode 
+                => Code;
         }
 
-        bool IExecuteResult.IsSuccess => Error == null;
+        bool IExecuteResult.IsSuccess 
+            => Error is null;
 
-        IExecuteError? IExecuteResult.ExecutionError => Error;
+        IExecuteError? IExecuteResult.ExecutionError 
+            => Error;
 
-        Exception? IExecuteResult.Exception => null;
+        Exception? IExecuteResult.Exception 
+            => null;
 
-        string? IExecuteResult.ExecutedQuery => null;
+        string? IExecuteResult.ExecutedQuery 
+            => null;
     }
 
     public class EdgeDBHttpClient : BaseEdgeDBClient
@@ -77,11 +85,13 @@ namespace EdgeDB
             _config = config;
             _connection = connection;
             Uri = new($"http{(connection.TLSSecurity != TLSSecurityMode.Insecure ? "s" : "")}://{connection.Hostname}:{connection.Port}/db/{connection.Database}/edgeql");
-            
-            var handler = new HttpClientHandler();
-            handler.ClientCertificateOptions = ClientCertificateOption.Manual;
-            handler.SslProtocols = SslProtocols.None;
-            handler.ServerCertificateCustomValidationCallback = ValidateServerCertificate;
+
+            var handler = new HttpClientHandler
+            {
+                ClientCertificateOptions = ClientCertificateOption.Manual,
+                SslProtocols = SslProtocols.None,
+                ServerCertificateCustomValidationCallback = ValidateServerCertificate
+            };
             _httpClient = new(handler);
         }
 
@@ -147,7 +157,7 @@ namespace EdgeDB
         {
             var result = await ExecuteInternalAsync(query, args);
 
-            if (result.Data == null)
+            if (result.Data is null)
                 return Array.Empty<TResult?>();
 
             var arr = (JArray)result.Data;
@@ -158,12 +168,12 @@ namespace EdgeDB
         {
             var result = await ExecuteInternalAsync(query, args);
 
-            if (result.Data == null)
+            if (result.Data is null)
                 throw new MissingRequiredException();
 
             var arr = (JArray)result.Data;
 
-            if (arr.Count != 1)
+            if (arr.Count is not 1)
                 throw new InvalidDataException($"Expected 1 element but got {arr.Count}", new MissingRequiredException());
 
             return arr[0].ToObject<TResult>()!;
@@ -174,7 +184,7 @@ namespace EdgeDB
         {
             var result = await ExecuteInternalAsync(query, args);
 
-            if (result.Data == null)
+            if (result.Data is null)
                 return default;
 
             var arr = (JArray)result.Data;

--- a/src/EdgeDB.Net.Driver/Clients/EdgeDBTcpClient.cs
+++ b/src/EdgeDB.Net.Driver/Clients/EdgeDBTcpClient.cs
@@ -93,10 +93,10 @@ namespace EdgeDB
 
         private bool ValidateServerCertificate(object sender, X509Certificate? certificate, X509Chain? chain, SslPolicyErrors sslPolicyErrors)
         {
-            if (Connection.TLSSecurity == TLSSecurityMode.Insecure)
+            if (Connection.TLSSecurity is TLSSecurityMode.Insecure)
                 return true;
 
-            if (Connection.TLSCertificateAuthority != null)
+            if (Connection.TLSCertificateAuthority is not null)
             {
                 var cert = Connection.GetCertificate()!;
 
@@ -113,7 +113,7 @@ namespace EdgeDB
             }
             else
             {
-                return sslPolicyErrors == SslPolicyErrors.None;
+                return sslPolicyErrors is SslPolicyErrors.None;
             }
         }
 
@@ -125,7 +125,7 @@ namespace EdgeDB
             {
                 _stream?.Dispose();
 
-                if (_secureStream != null)
+                if (_secureStream is not null)
                     await _secureStream.DisposeAsync();
             }
 

--- a/src/EdgeDB.Net.Driver/Clients/ITransactibleClient.cs
+++ b/src/EdgeDB.Net.Driver/Clients/ITransactibleClient.cs
@@ -12,7 +12,9 @@ namespace EdgeDB
         TransactionState TransactionState { get; }
 
         Task StartTransactionAsync(Isolation isolation, bool readOnly, bool deferrable);
+
         Task CommitAsync();
+
         Task RollbackAsync();
     }
 }

--- a/src/EdgeDB.Net.Driver/Codecs/Array.cs
+++ b/src/EdgeDB.Net.Driver/Codecs/Array.cs
@@ -16,12 +16,12 @@
             // skip reserved
             reader.ReadBytes(8);
 
-            if (dimensions == 0)
+            if (dimensions is 0)
             {
                 return Array.Empty<TInner>();
             }
 
-            if(dimensions != 1)
+            if(dimensions is not 1)
             {
                 throw new NotSupportedException("Only dimensions of 1 are supported for arrays");
             }
@@ -39,10 +39,8 @@
                 var innerData = reader.ReadBytes(elementLength);
 
                 // TODO: optimize this stream creation?
-                using(var innerReader = new PacketReader(innerData))
-                {
-                    array[i] = _innerCodec.Deserialize(innerReader);
-                }
+                using var innerReader = new PacketReader(innerData);
+                array[i] = _innerCodec.Deserialize(innerReader);
             }
 
             return array;
@@ -50,7 +48,7 @@
 
         public void Serialize(PacketWriter writer, IEnumerable<TInner?>? value)
         {
-            if(value == null)
+            if(value is null)
             {
                 writer.Write(0);
                 writer.Write(0); // flags?
@@ -68,7 +66,7 @@
             {
                 var element = elements[i];
 
-                if(element == null)
+                if(element is null)
                 {
                     elementWriter.Write(-1);
                 }

--- a/src/EdgeDB.Net.Driver/Codecs/BigInt.cs
+++ b/src/EdgeDB.Net.Driver/Codecs/BigInt.cs
@@ -37,6 +37,7 @@ namespace EdgeDB.Codecs
             return BigInteger.Parse(result);
         }
 
-        public void Serialize(PacketWriter writer, BigInteger value) => throw new NotImplementedException();
+        public void Serialize(PacketWriter writer, BigInteger value) 
+            => throw new NotImplementedException();
     }
 }

--- a/src/EdgeDB.Net.Driver/Codecs/Bytes.cs
+++ b/src/EdgeDB.Net.Driver/Codecs/Bytes.cs
@@ -9,7 +9,7 @@
 
         public void Serialize(PacketWriter writer, byte[]? value)
         {
-            if (value != null)
+            if (value is not null)
                 writer.Write(value);
         }
     }

--- a/src/EdgeDB.Net.Driver/Codecs/Decimal.cs
+++ b/src/EdgeDB.Net.Driver/Codecs/Decimal.cs
@@ -13,7 +13,7 @@
 
             string value = "";
 
-            if (sign == NumericSign.NEG)
+            if (sign is NumericSign.NEG)
                 value += "-";
 
             int d;

--- a/src/EdgeDB.Net.Driver/Codecs/ICodec.cs
+++ b/src/EdgeDB.Net.Driver/Codecs/ICodec.cs
@@ -10,6 +10,7 @@ namespace EdgeDB.Codecs
     internal interface IArgumentCodec
     {
         void SerializeArguments(PacketWriter writer, object? value);
+
         byte[] SerializeArguments(object? value)
         {
             using var writer = new PacketWriter();
@@ -25,6 +26,7 @@ namespace EdgeDB.Codecs
     internal interface ICodec<TConverter> : ICodec
     {
         void Serialize(PacketWriter writer, TConverter? value);
+
         new TConverter? Deserialize(PacketReader reader);
 
         new TConverter? Deserialize(byte[] buffer)
@@ -45,17 +47,27 @@ namespace EdgeDB.Codecs
         }
 
         // ICodec
-        object? ICodec.Deserialize(PacketReader reader) => Deserialize(reader);
-        void ICodec.Serialize(PacketWriter writer, object? value) => Serialize(writer, (TConverter?)value);
-        Type ICodec.ConverterType => typeof(TConverter);
-        bool ICodec.CanConvert(Type t) => t == typeof(TConverter);
+        object? ICodec.Deserialize(PacketReader reader) 
+            => Deserialize(reader);
+
+        void ICodec.Serialize(PacketWriter writer, object? value) 
+            => Serialize(writer, (TConverter?)value);
+
+        Type ICodec.ConverterType 
+            => typeof(TConverter);
+
+        bool ICodec.CanConvert(Type t)
+            => t == typeof(TConverter);
     }
 
     internal interface ICodec
     {
         bool CanConvert(Type t);
+
         Type ConverterType { get; }
+
         void Serialize(PacketWriter writer, object? value);
+
         object? Deserialize(PacketReader reader);
 
         object? Deserialize(byte[] buffer)

--- a/src/EdgeDB.Net.Driver/Codecs/NullCodec.cs
+++ b/src/EdgeDB.Net.Driver/Codecs/NullCodec.cs
@@ -13,12 +13,12 @@
 
         public void Serialize(PacketWriter writer, object? value)
         {
-            writer.Write((int)0);
+            writer.Write(0);
         }
 
         public void SerializeArguments(PacketWriter writer, object? value)
         {
-            writer.Write((int)0);
+            writer.Write(0);
         }
     }
 }

--- a/src/EdgeDB.Net.Driver/Codecs/Set.cs
+++ b/src/EdgeDB.Net.Driver/Codecs/Set.cs
@@ -28,12 +28,12 @@
             // discard flags and reserved
             reader.ReadBytes(8);
 
-            if(dimensions == 0)
+            if(dimensions is 0)
             {
                 return Array.Empty<TInner>();
             }
 
-            if(dimensions != 1)
+            if(dimensions is not 1)
             {
                 throw new NotSupportedException("Only dimensions of 1 are supported for arrays");
             }
@@ -71,12 +71,12 @@
             // discard flags and reserved
             reader.ReadBytes(8);
 
-            if (dimensions == 0)
+            if (dimensions is 0)
             {
                 return Array.Empty<TInner>();
             }
 
-            if (dimensions != 1)
+            if (dimensions is not 1)
             {
                 throw new NotSupportedException("Only dimensions of 1 are supported for sets");
             }
@@ -92,7 +92,7 @@
             {
                 var elementLength = reader.ReadInt32();
 
-                if (elementLength == -1)
+                if (elementLength is -1)
                     result[i] = default; // TODO: better 'null' value handling?
                 else
                     result[i] = _innerCodec.Deserialize(reader);

--- a/src/EdgeDB.Net.Driver/Codecs/Shared/Dimension.cs
+++ b/src/EdgeDB.Net.Driver/Codecs/Shared/Dimension.cs
@@ -3,6 +3,7 @@
     internal struct Dimension
     {
         public int Upper { get; set; }
+
         public int Lower { get; set; }
     }
 }

--- a/src/EdgeDB.Net.Driver/Codecs/Shared/Element.cs
+++ b/src/EdgeDB.Net.Driver/Codecs/Shared/Element.cs
@@ -3,6 +3,7 @@
     internal struct Element
     {
         public int Reserved { get; set; }
+
         public int Length { get; set; }
 
         public byte[] Data { get; set; }

--- a/src/EdgeDB.Net.Driver/Codecs/Text.cs
+++ b/src/EdgeDB.Net.Driver/Codecs/Text.cs
@@ -11,7 +11,7 @@ namespace EdgeDB.Codecs
 
         public void Serialize(PacketWriter writer, string? value)
         {
-            if (value != null)
+            if (value is not null)
                 writer.Write(Encoding.UTF8.GetBytes(value));
         }
     }

--- a/src/EdgeDB.Net.Driver/Codecs/Tuple.cs
+++ b/src/EdgeDB.Net.Driver/Codecs/Tuple.cs
@@ -24,7 +24,7 @@ namespace EdgeDB.Codecs
             var tupleType = Type.GetType($"System.Tuple`{numElements}");
 
             // TODO: support extended tuple types.
-            if(tupleType == null)
+            if(tupleType is null)
             {
                 throw new NotSupportedException("Failed to find tuple match.");
             }
@@ -41,7 +41,7 @@ namespace EdgeDB.Codecs
 
                 var length = reader.ReadInt32();
                 
-                if(length == 0)
+                if(length is 0)
                 {
                     values[i] = null;
                     continue;
@@ -51,10 +51,8 @@ namespace EdgeDB.Codecs
                 var data = reader.ReadBytes(length);
 
                 // TODO: optimize this?
-                using(var innerReader = new PacketReader(data))
-                {
-                    values[i] = _innerCodecs[i].Deserialize(innerReader);
-                }
+                using var innerReader = new PacketReader(data);
+                values[i] = _innerCodecs[i].Deserialize(innerReader);
             }
 
             // construct our tuple

--- a/src/EdgeDB.Net.Driver/EdgeDBClient.cs
+++ b/src/EdgeDB.Net.Driver/EdgeDBClient.cs
@@ -42,7 +42,7 @@ namespace EdgeDB
         private ConcurrentStack<BaseEdgeDBClient> _availableClients;
         private bool _isInitialized;
         private Dictionary<string, object?> _edgedbConfig;
-        private int _poolSize;
+        private uint _poolSize;
 
         private readonly object _clientsLock = new();
         private readonly SemaphoreSlim _initSemaphore;
@@ -89,9 +89,6 @@ namespace EdgeDB
             if (config.ClientType == EdgeDBClientType.Custom && config.ClientFactory == null)
                 throw new CustomClientException("You must specify a client factory in order to use custom clients");
 
-            if (config.DefaultPoolSize < 1)
-                throw new ArgumentOutOfRangeException(nameof(config.DefaultPoolSize), "Pool size must be above zero");
-
             _clientFactory = config.ClientFactory;
 
             _isInitialized = false;
@@ -122,7 +119,7 @@ namespace EdgeDB
                 if(client is EdgeDBBinaryClient binaryClient)
                 {
                     // set the pool size to the recommended
-                    _poolSize = binaryClient.SuggestedPoolConcurrency;
+                    _poolSize = (uint)binaryClient.SuggestedPoolConcurrency;
                     _edgedbConfig = binaryClient.RawServerConfig;
                 }
 

--- a/src/EdgeDB.Net.Driver/EdgeDBConfig.cs
+++ b/src/EdgeDB.Net.Driver/EdgeDBConfig.cs
@@ -7,7 +7,7 @@ namespace EdgeDB
         /// <summary>
         ///     Gets or sets the default client pool size.
         /// </summary>
-        public int DefaultPoolSize { get; set; } = 50;
+        public uint DefaultPoolSize { get; set; } = 50;
 
         /// <summary>
         ///     Gets or sets the client type the pool will use.

--- a/src/EdgeDB.Net.Driver/EdgeDBConnection.cs
+++ b/src/EdgeDB.Net.Driver/EdgeDBConnection.cs
@@ -81,15 +81,15 @@ namespace EdgeDB
         {
             string str = "edgedb://";
 
-            if (Username != null)
+            if (Username is not null)
                 str += Username;
-            if (Password != null && Username != null)
+            if (Password is not null && Username is not null)
                 str += $":{Password}";
 
-            if (Hostname != null)
+            if (Hostname is not null)
                 str += $"@{Hostname}:{Port}";
 
-            if (Database != null)
+            if (Database is not null)
                 str += $"/{Database}";
 
             return str;
@@ -183,19 +183,19 @@ namespace EdgeDB
 
             var conn = new EdgeDBConnection();
 
-            if (database != null)
+            if (database is not null)
                 conn.Database = database;
 
-            if (host != null)
+            if (host is not null)
                 conn.Hostname = host;
 
-            if (username != null)
+            if (username is not null)
                 conn.Username = username;
 
-            if (password != null)
+            if (password is not null)
                 conn.Password = password;
 
-            if (port != null)
+            if (port is not null)
             {
                 if (!int.TryParse(port, out var parsedPort))
                     throw new FormatException("port was not in the correct format");
@@ -212,7 +212,7 @@ namespace EdgeDB
                 {
                     case "port":
                         {
-                            if (port != null)
+                            if (port is not null)
                                 throw new ArgumentException("Port ambiguity mismatch");
 
                             if (!int.TryParse(value, out var parsedPort))
@@ -222,25 +222,25 @@ namespace EdgeDB
                         }
                         break;
                     case "host":
-                        if (host != null)
+                        if (host is not null)
                             throw new ArgumentException("Port ambiguity mismatch");
 
                         conn.Hostname = value;
                         break;
                     case "database":
-                        if (database != null)
+                        if (database is not null)
                             throw new ArgumentException("Port ambiguity mismatch");
 
                         conn.Database = value;
                         break;
                     case "user":
-                        if (username != null)
+                        if (username is not null)
                             throw new ArgumentException("Port ambiguity mismatch");
 
                         conn.Username = value;
                         break;
                     case "password":
-                        if (password != null)
+                        if (password is not null)
                             throw new ArgumentException("Port ambiguity mismatch");
 
                         conn.Password = value;
@@ -352,7 +352,7 @@ namespace EdgeDB
 
                 var parent = Directory.GetParent(dir!);
 
-                if (parent == null || !parent.Exists)
+                if (parent is null || !parent.Exists)
                     throw new FileNotFoundException("Couldn't resolve edgedb.toml file");
 
                 dir = parent.FullName;

--- a/src/EdgeDB.Net.Driver/Extensions/ClientPoolExtensions.cs
+++ b/src/EdgeDB.Net.Driver/Extensions/ClientPoolExtensions.cs
@@ -5,9 +5,7 @@ namespace EdgeDB
     public static class ClientPoolExtensions
     {
         public static bool SupportsTransactions(this EdgeDBClient client)
-        {
-            return client.ClientType == EdgeDBClientType.Tcp;
-        }
+            => client.ClientType is EdgeDBClientType.Tcp;
 
         #region Transactions
         /// <summary>

--- a/src/EdgeDB.Net.Driver/Extensions/ConnectionExtensions.cs
+++ b/src/EdgeDB.Net.Driver/Extensions/ConnectionExtensions.cs
@@ -12,7 +12,7 @@ namespace EdgeDB
     {
         public static X509Certificate2? GetCertificate(this EdgeDBConnection connection)
         {
-            if (connection.TLSCertificateAuthority == null)
+            if (connection.TLSCertificateAuthority is null)
                 return null;
 
             return new X509Certificate2(Encoding.ASCII.GetBytes(connection.TLSCertificateAuthority));

--- a/src/EdgeDB.Net.Driver/Models/Descriptors/ArrayTypeDescriptor.cs
+++ b/src/EdgeDB.Net.Driver/Models/Descriptors/ArrayTypeDescriptor.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal struct ArrayTypeDescriptor : ITypeDescriptor
     {
-        public DescriptorType Type => DescriptorType.ArrayTypeDescriptor;
+        public DescriptorType Type 
+            => DescriptorType.ArrayTypeDescriptor;
 
         public Guid Id { get; set; }
 

--- a/src/EdgeDB.Net.Driver/Models/Descriptors/BaseScalarTypeDescriptor.cs
+++ b/src/EdgeDB.Net.Driver/Models/Descriptors/BaseScalarTypeDescriptor.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal struct BaseScalarTypeDescriptor : ITypeDescriptor
     {
-        public DescriptorType Type => DescriptorType.BaseScalarTypeDescriptor;
+        public DescriptorType Type 
+            => DescriptorType.BaseScalarTypeDescriptor;
 
         public Guid Id { get; set; }
 

--- a/src/EdgeDB.Net.Driver/Models/Descriptors/EnumerationTypeDescriptor.cs
+++ b/src/EdgeDB.Net.Driver/Models/Descriptors/EnumerationTypeDescriptor.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal struct EnumerationTypeDescriptor : ITypeDescriptor
     {
-        public DescriptorType Type => DescriptorType.EnumerationTypeDescriptor;
+        public DescriptorType Type 
+            => DescriptorType.EnumerationTypeDescriptor;
 
         public Guid Id { get; set; }
 

--- a/src/EdgeDB.Net.Driver/Models/Descriptors/ITypeDescriptor.cs
+++ b/src/EdgeDB.Net.Driver/Models/Descriptors/ITypeDescriptor.cs
@@ -9,6 +9,7 @@ namespace EdgeDB.Models
     internal interface ITypeDescriptor
     {
         DescriptorType Type { get; }
+
         Guid Id { get; }
 
         void Read(PacketReader reader);
@@ -32,7 +33,7 @@ namespace EdgeDB.Models
                 _ => null
             };
 
-            if(descriptor == null)
+            if(descriptor is null)
             {
                 var rawType = (byte)type;
 

--- a/src/EdgeDB.Net.Driver/Models/Descriptors/NamedTupleTypeDescriptor.cs
+++ b/src/EdgeDB.Net.Driver/Models/Descriptors/NamedTupleTypeDescriptor.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal struct NamedTupleTypeDescriptor : ITypeDescriptor
     {
-        public DescriptorType Type => DescriptorType.NamedTupleDescriptor;
+        public DescriptorType Type 
+            => DescriptorType.NamedTupleDescriptor;
 
         public Guid Id { get; set; }
 
@@ -39,6 +40,7 @@ namespace EdgeDB.Models
     internal struct TupleElement
     {
         public string Name { get; set; }
+
         public short TypePos { get; set; }
     }
 }

--- a/src/EdgeDB.Net.Driver/Models/Descriptors/ObjectShapeDescriptor.cs
+++ b/src/EdgeDB.Net.Driver/Models/Descriptors/ObjectShapeDescriptor.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal struct ObjectShapeDescriptor : ITypeDescriptor
     {
-        public DescriptorType Type => DescriptorType.ObjectShapeDescriptor;
+        public DescriptorType Type 
+            => DescriptorType.ObjectShapeDescriptor;
 
         public Guid Id { get; set; }
 

--- a/src/EdgeDB.Net.Driver/Models/Descriptors/ScalarTypeDescriptor.cs
+++ b/src/EdgeDB.Net.Driver/Models/Descriptors/ScalarTypeDescriptor.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal struct ScalarTypeDescriptor : ITypeDescriptor
     {
-        public DescriptorType Type => DescriptorType.ScalarTypeDescriptor;
+        public DescriptorType Type 
+            => DescriptorType.ScalarTypeDescriptor;
 
         public Guid Id { get; set; }
 

--- a/src/EdgeDB.Net.Driver/Models/Descriptors/ScalarTypeNameAnnotation.cs
+++ b/src/EdgeDB.Net.Driver/Models/Descriptors/ScalarTypeNameAnnotation.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal struct ScalarTypeNameAnnotation : ITypeDescriptor
     {
-        public DescriptorType Type => DescriptorType.ScalarTypeNameAnnotation;
+        public DescriptorType Type 
+            => DescriptorType.ScalarTypeNameAnnotation;
 
         public Guid Id { get; set; }
 

--- a/src/EdgeDB.Net.Driver/Models/Descriptors/SetDescriptor.cs
+++ b/src/EdgeDB.Net.Driver/Models/Descriptors/SetDescriptor.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal struct SetDescriptor : ITypeDescriptor
     {
-        public DescriptorType Type => DescriptorType.SetDescriptor;
+        public DescriptorType Type 
+            => DescriptorType.SetDescriptor;
 
         public Guid Id { get; set; }
 

--- a/src/EdgeDB.Net.Driver/Models/Descriptors/TupleTypeDescriptor.cs
+++ b/src/EdgeDB.Net.Driver/Models/Descriptors/TupleTypeDescriptor.cs
@@ -8,11 +8,13 @@ namespace EdgeDB.Models
 {
     internal struct TupleTypeDescriptor : ITypeDescriptor
     {
-        public DescriptorType Type => DescriptorType.TupleTypeDescriptor;
+        public DescriptorType Type 
+            => DescriptorType.TupleTypeDescriptor;
 
         public Guid Id { get; set; }
 
-        public bool IsEmpty => Id.ToString() == "00000000-0000-0000-0000-0000000000FF";
+        public bool IsEmpty 
+            => Id.ToString() == "00000000-0000-0000-0000-0000000000FF";
 
         public ushort[] ElementTypeDescriptorsIndex { get; set; }
 

--- a/src/EdgeDB.Net.Driver/Models/ExecuteResult.cs
+++ b/src/EdgeDB.Net.Driver/Models/ExecuteResult.cs
@@ -58,6 +58,7 @@
     public interface IExecuteError
     {
         string? Message { get; }
+
         uint ErrorCode { get; }
     }
 }

--- a/src/EdgeDB.Net.Driver/Models/Headers/Header.cs
+++ b/src/EdgeDB.Net.Driver/Models/Headers/Header.cs
@@ -25,8 +25,6 @@ namespace EdgeDB.Models
         ///     Converts this headers value to a UTF8 encoded string
         /// </summary>
         public override string ToString()
-        {
-            return Encoding.UTF8.GetString(Value);
-        }
+            => Encoding.UTF8.GetString(Value);
     }
 }

--- a/src/EdgeDB.Net.Driver/Models/IReceiveable.cs
+++ b/src/EdgeDB.Net.Driver/Models/IReceiveable.cs
@@ -17,6 +17,7 @@ namespace EdgeDB.Models
         ServerMessageType Type { get; }
 
         internal ulong Id { get; set; }
+
         internal void Read(PacketReader reader, uint length, EdgeDBBinaryClient client);
 
         internal IReceiveable Clone();

--- a/src/EdgeDB.Net.Driver/Models/Receivables/AuthenticationStatus.cs
+++ b/src/EdgeDB.Net.Driver/Models/Receivables/AuthenticationStatus.cs
@@ -15,7 +15,8 @@ namespace EdgeDB.Models
     public struct AuthenticationStatus : IReceiveable
     {
         /// <inheritdoc/>
-        public ServerMessageType Type => ServerMessageType.Authentication;
+        public ServerMessageType Type 
+            => ServerMessageType.Authentication;
 
         /// <summary>
         ///     Gets the authentication state. 

--- a/src/EdgeDB.Net.Driver/Models/Receivables/CommandComplete.cs
+++ b/src/EdgeDB.Net.Driver/Models/Receivables/CommandComplete.cs
@@ -13,7 +13,8 @@ namespace EdgeDB.Models
     public struct CommandComplete : IReceiveable
     {
         /// <inheritdoc/>
-        public ServerMessageType Type => ServerMessageType.CommandComplete;
+        public ServerMessageType Type 
+            => ServerMessageType.CommandComplete;
 
         /// <summary>
         ///     Gets the used capabilities within the completed command.

--- a/src/EdgeDB.Net.Driver/Models/Receivables/CommandDataDescription.cs
+++ b/src/EdgeDB.Net.Driver/Models/Receivables/CommandDataDescription.cs
@@ -12,7 +12,8 @@ namespace EdgeDB.Models
     public struct CommandDataDescription : IReceiveable
     {
         /// <inheritdoc/>
-        public ServerMessageType Type => ServerMessageType.CommandDataDescription;
+        public ServerMessageType Type 
+            => ServerMessageType.CommandDataDescription;
 
         /// <summary>
         ///     Gets a read-only collection of headers.

--- a/src/EdgeDB.Net.Driver/Models/Receivables/Data.cs
+++ b/src/EdgeDB.Net.Driver/Models/Receivables/Data.cs
@@ -6,7 +6,8 @@
     public struct Data : IReceiveable
     {
         /// <inheritdoc/>
-        public ServerMessageType Type => ServerMessageType.Data;
+        public ServerMessageType Type 
+            => ServerMessageType.Data;
 
         /// <summary>
         ///     Gets the payload of this data packet

--- a/src/EdgeDB.Net.Driver/Models/Receivables/DumpBlock.cs
+++ b/src/EdgeDB.Net.Driver/Models/Receivables/DumpBlock.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
     public struct DumpBlock : IReceiveable
     {
         /// <inheritdoc/>
-        public ServerMessageType Type => ServerMessageType.DumpBlock;
+        public ServerMessageType Type 
+            => ServerMessageType.DumpBlock;
 
         /// <summary>
         ///     Gets the sha1 hash of this packets data, used when writing a dump file.
@@ -28,22 +29,26 @@ namespace EdgeDB.Models
         /// <summary>
         ///     Gets a collection of block type headers derived from the <see cref="Headers"/> collection.
         /// </summary>
-        public IEnumerable<Header> BlockTypes => Headers.Where(x => x.Code == 101);
+        public IEnumerable<Header> BlockTypes 
+            => Headers.Where(x => x.Code == 101);
 
         /// <summary>
         ///     Gets a collection of block id headers derived from the <see cref="Headers"/> collection.
         /// </summary>
-        public IEnumerable<Header> BlockIds => Headers.Where(x => x.Code == 110);
+        public IEnumerable<Header> BlockIds 
+            => Headers.Where(x => x.Code == 110);
 
         /// <summary>
         ///     Gets a collection of block number headers derived from the <see cref="Headers"/> collection.
         /// </summary>
-        public IEnumerable<Header> BlockNumbers => Headers.Where(x => x.Code == 111);
+        public IEnumerable<Header> BlockNumbers 
+            => Headers.Where(x => x.Code == 111);
 
         /// <summary>
         ///     Gets a collection of block data headers derived from the <see cref="Headers"/> collection.
         /// </summary>
-        public IEnumerable<Header> BlockData => Headers.Where(x => x.Code == 112);
+        public IEnumerable<Header> BlockData 
+            => Headers.Where(x => x.Code == 112);
 
         internal byte[] Raw { get; private set; }
         ulong IReceiveable.Id { get; set; }
@@ -56,10 +61,8 @@ namespace EdgeDB.Models
 
             Hash = SHA1.Create().ComputeHash(Raw);
 
-            using (var r = new PacketReader(Raw))
-            {
-                Headers = r.ReadHeaders();
-            }
+            using var r = new PacketReader(Raw);
+            Headers = r.ReadHeaders();
         }
 
         IReceiveable IReceiveable.Clone()

--- a/src/EdgeDB.Net.Driver/Models/Receivables/DumpHeader.cs
+++ b/src/EdgeDB.Net.Driver/Models/Receivables/DumpHeader.cs
@@ -13,7 +13,8 @@ namespace EdgeDB.Models
     public struct DumpHeader : IReceiveable
     {
         /// <inheritdoc/>
-        public ServerMessageType Type => ServerMessageType.DumpHeader;
+        public ServerMessageType Type 
+            => ServerMessageType.DumpHeader;
 
         /// <summary>
         ///     Gets the sha1 hash of this packets data, used when writing a dump file.
@@ -56,7 +57,9 @@ namespace EdgeDB.Models
         public IReadOnlyCollection<DumpObjectDescriptor> Descriptors { get; private set; }
 
         internal byte[] Raw { get; private set; }
+
         ulong IReceiveable.Id { get; set; }
+
         void IReceiveable.Read(PacketReader reader, uint length, EdgeDBBinaryClient client)
         {
             Length = length;
@@ -64,28 +67,27 @@ namespace EdgeDB.Models
 
             Hash = SHA1.Create().ComputeHash(Raw);
 
-            using(var r = new PacketReader(Raw))
-            {
-                Headers = r.ReadHeaders();
-                MajorVersion = r.ReadUInt16();
-                MinorVersion = r.ReadUInt16();
-                SchemaDDL = r.ReadString();
+            using var r = new PacketReader(Raw);
 
-                var numTypeInfo = r.ReadUInt32();
-                DumpTypeInfo[] typeInfo = new DumpTypeInfo[numTypeInfo];
+            Headers = r.ReadHeaders();
+            MajorVersion = r.ReadUInt16();
+            MinorVersion = r.ReadUInt16();
+            SchemaDDL = r.ReadString();
 
-                for (uint i = 0; i != numTypeInfo; i++)
-                    typeInfo[i] = new DumpTypeInfo().Read(r);
+            var numTypeInfo = r.ReadUInt32();
+            DumpTypeInfo[] typeInfo = new DumpTypeInfo[numTypeInfo];
 
-                var numDescriptors = r.ReadUInt32();
-                DumpObjectDescriptor[] descriptors = new DumpObjectDescriptor[numDescriptors];
+            for (uint i = 0; i != numTypeInfo; i++)
+                typeInfo[i] = new DumpTypeInfo().Read(r);
 
-                for (uint i = 0; i != numDescriptors; i++)
-                    descriptors[i] = new DumpObjectDescriptor().Read(r);
+            var numDescriptors = r.ReadUInt32();
+            DumpObjectDescriptor[] descriptors = new DumpObjectDescriptor[numDescriptors];
 
-                Types = typeInfo;
-                Descriptors = descriptors;
-            }
+            for (uint i = 0; i != numDescriptors; i++)
+                descriptors[i] = new DumpObjectDescriptor().Read(r);
+
+            Types = typeInfo;
+            Descriptors = descriptors;
         }
 
         IReceiveable IReceiveable.Clone()

--- a/src/EdgeDB.Net.Driver/Models/Receivables/ErrorResponse.cs
+++ b/src/EdgeDB.Net.Driver/Models/Receivables/ErrorResponse.cs
@@ -13,7 +13,8 @@ namespace EdgeDB.Models
     public struct ErrorResponse : IReceiveable, IExecuteError
     {
         /// <inheritdoc/>
-        public ServerMessageType Type => ServerMessageType.ErrorResponse;
+        public ServerMessageType Type 
+            => ServerMessageType.ErrorResponse;
 
         /// <summary>
         ///     Gets the severity of the error.

--- a/src/EdgeDB.Net.Driver/Models/Receivables/ParameterStatus.cs
+++ b/src/EdgeDB.Net.Driver/Models/Receivables/ParameterStatus.cs
@@ -12,7 +12,8 @@ namespace EdgeDB.Models
     public struct ParameterStatus : IReceiveable
     {
         /// <inheritdoc/>
-        public ServerMessageType Type => ServerMessageType.ParameterStatus;
+        public ServerMessageType Type 
+            => ServerMessageType.ParameterStatus;
 
         /// <summary>
         ///     Gets the name of the parameter.

--- a/src/EdgeDB.Net.Driver/Models/Receivables/PrepareComplete.cs
+++ b/src/EdgeDB.Net.Driver/Models/Receivables/PrepareComplete.cs
@@ -13,7 +13,8 @@ namespace EdgeDB.Models
     public struct PrepareComplete : IReceiveable
     {
         /// <inheritdoc/>
-        public ServerMessageType Type => ServerMessageType.PrepareComplete;
+        public ServerMessageType Type 
+            => ServerMessageType.PrepareComplete;
 
         /// <summary>
         ///     Gets the allowed capabilities that the command will actually use.
@@ -43,10 +44,8 @@ namespace EdgeDB.Models
 
             var capabilities = headers.Cast<Header?>().FirstOrDefault(x => x!.Value.Code == 0x1001);
 
-            if(capabilities != null)
-            {
+            if(capabilities is not null)
                 Capabilities = (AllowCapabilities)ICodec.GetScalarCodec<long>()!.Deserialize(capabilities.Value.Value);
-            }
 
             Cardinality = (Cardinality)reader.ReadByte();
             InputTypedescId = reader.ReadGuid();

--- a/src/EdgeDB.Net.Driver/Models/Receivables/ReadyForCommand.cs
+++ b/src/EdgeDB.Net.Driver/Models/Receivables/ReadyForCommand.cs
@@ -6,7 +6,8 @@
     public struct ReadyForCommand : IReceiveable
     {
         /// <inheritdoc/>
-        public ServerMessageType Type => ServerMessageType.ReadyForCommand;
+        public ServerMessageType Type 
+            => ServerMessageType.ReadyForCommand;
 
         /// <summary>
         ///     Gets a collection of headers sent with this prepare packet.

--- a/src/EdgeDB.Net.Driver/Models/Receivables/RestoreReady.cs
+++ b/src/EdgeDB.Net.Driver/Models/Receivables/RestoreReady.cs
@@ -12,7 +12,8 @@ namespace EdgeDB.Models
     public struct RestoreReady : IReceiveable
     {
         /// <inheritdoc/>
-        public ServerMessageType Type => ServerMessageType.RestoreReady;
+        public ServerMessageType Type 
+            => ServerMessageType.RestoreReady;
 
         /// <summary>
         ///     Gets a collection of headers that was sent with this packet.
@@ -31,6 +32,8 @@ namespace EdgeDB.Models
         }
 
         ulong IReceiveable.Id { get; set; }
-        IReceiveable IReceiveable.Clone() => (IReceiveable)MemberwiseClone();
+
+        IReceiveable IReceiveable.Clone() 
+            => (IReceiveable)MemberwiseClone();
     }
 }

--- a/src/EdgeDB.Net.Driver/Models/Receivables/ServerHandshake.cs
+++ b/src/EdgeDB.Net.Driver/Models/Receivables/ServerHandshake.cs
@@ -12,7 +12,8 @@ namespace EdgeDB.Models.Receivables
     public struct ServerHandshake : IReceiveable
     {
         /// <inheritdoc/>
-        public ServerMessageType Type => ServerMessageType.ServerHandshake;
+        public ServerMessageType Type 
+            => ServerMessageType.ServerHandshake;
 
         /// <summary>
         ///     Gets the major version of the server.

--- a/src/EdgeDB.Net.Driver/Models/Receivables/ServerKeyData.cs
+++ b/src/EdgeDB.Net.Driver/Models/Receivables/ServerKeyData.cs
@@ -12,7 +12,8 @@ namespace EdgeDB.Models
     public struct ServerKeyData : IReceiveable
     {
         /// <inheritdoc/>
-        public ServerMessageType Type => ServerMessageType.ServerKeyData;
+        public ServerMessageType Type 
+            => ServerMessageType.ServerKeyData;
 
         /// <summary>
         ///     Get the key data.

--- a/src/EdgeDB.Net.Driver/Models/Sendables/AuthenticationSASLInitialResponse.cs
+++ b/src/EdgeDB.Net.Driver/Models/Sendables/AuthenticationSASLInitialResponse.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal class AuthenticationSASLInitialResponse : Sendable
     {
-        public override ClientMessageTypes Type => ClientMessageTypes.AuthenticationSASLInitialResponse;
+        public override ClientMessageTypes Type 
+            => ClientMessageTypes.AuthenticationSASLInitialResponse;
 
         public string Method { get; set; }
 

--- a/src/EdgeDB.Net.Driver/Models/Sendables/AuthenticationSASLResponse.cs
+++ b/src/EdgeDB.Net.Driver/Models/Sendables/AuthenticationSASLResponse.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal class AuthenticationSASLResponse : Sendable
     {
-        public override ClientMessageTypes Type => ClientMessageTypes.AuthenticationSASLResponse;
+        public override ClientMessageTypes Type 
+            => ClientMessageTypes.AuthenticationSASLResponse;
 
         private readonly byte[] _payload;
 

--- a/src/EdgeDB.Net.Driver/Models/Sendables/DescribeStatement.cs
+++ b/src/EdgeDB.Net.Driver/Models/Sendables/DescribeStatement.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal class DescribeStatement : Sendable
     {
-        public override ClientMessageTypes Type => ClientMessageTypes.DescribeStatement;
+        public override ClientMessageTypes Type 
+            => ClientMessageTypes.DescribeStatement;
 
         public DescribeAspect DescribeAspect { get; set; } = DescribeAspect.DataDescription;
 

--- a/src/EdgeDB.Net.Driver/Models/Sendables/Dump.cs
+++ b/src/EdgeDB.Net.Driver/Models/Sendables/Dump.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal class Dump : Sendable
     {
-        public override ClientMessageTypes Type => ClientMessageTypes.Dump;
+        public override ClientMessageTypes Type 
+            => ClientMessageTypes.Dump;
 
         public Header[]? Headers { get; set; }
 

--- a/src/EdgeDB.Net.Driver/Models/Sendables/Execute.cs
+++ b/src/EdgeDB.Net.Driver/Models/Sendables/Execute.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal class Execute : Sendable
     {
-        public override ClientMessageTypes Type => ClientMessageTypes.Execute;
+        public override ClientMessageTypes Type 
+            => ClientMessageTypes.Execute;
 
         public AllowCapabilities Capabilities { get; set; }
 

--- a/src/EdgeDB.Net.Driver/Models/Sendables/Prepare.cs
+++ b/src/EdgeDB.Net.Driver/Models/Sendables/Prepare.cs
@@ -12,7 +12,8 @@ namespace EdgeDB.Models
     /// </summary>
     internal class Prepare : Sendable
     {
-        public override ClientMessageTypes Type => ClientMessageTypes.Prepare;
+        public override ClientMessageTypes Type 
+            => ClientMessageTypes.Prepare;
 
         /// <summary>
         ///     Implicit limit for objects returned.
@@ -52,7 +53,7 @@ namespace EdgeDB.Models
 
         protected override void BuildPacket(PacketWriter writer, EdgeDBBinaryClient client)
         {
-            if (Command == null)
+            if (Command is null)
                 throw new ArgumentException("Command cannot be null");
 
             List<Header> headers = new();

--- a/src/EdgeDB.Net.Driver/Models/Sendables/Restore.cs
+++ b/src/EdgeDB.Net.Driver/Models/Sendables/Restore.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal class Restore : Sendable
     {
-        public override ClientMessageTypes Type => ClientMessageTypes.Restore;
+        public override ClientMessageTypes Type 
+            => ClientMessageTypes.Restore;
 
         public Header[]? Headers { get; set; }
 

--- a/src/EdgeDB.Net.Driver/Models/Sendables/RestoreBlock.cs
+++ b/src/EdgeDB.Net.Driver/Models/Sendables/RestoreBlock.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal class RestoreBlock : Sendable
     {
-        public override ClientMessageTypes Type => ClientMessageTypes.RestoreBlock;
+        public override ClientMessageTypes Type 
+            => ClientMessageTypes.RestoreBlock;
 
         public byte[]? BlockData { get; set; }
 

--- a/src/EdgeDB.Net.Driver/Models/Sendables/RestoreEOF.cs
+++ b/src/EdgeDB.Net.Driver/Models/Sendables/RestoreEOF.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal class RestoreEOF : Sendable
     {
-        public override ClientMessageTypes Type => ClientMessageTypes.RestoreEOF;
+        public override ClientMessageTypes Type 
+            => ClientMessageTypes.RestoreEOF;
 
         protected override void BuildPacket(PacketWriter writer, EdgeDBBinaryClient client)
         {

--- a/src/EdgeDB.Net.Driver/Models/Sendables/Sync.cs
+++ b/src/EdgeDB.Net.Driver/Models/Sendables/Sync.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal class Sync : Sendable
     {
-        public override ClientMessageTypes Type => ClientMessageTypes.Sync;
+        public override ClientMessageTypes Type 
+            => ClientMessageTypes.Sync;
 
         protected override void BuildPacket(PacketWriter writer, EdgeDBBinaryClient client) { } // no data
     }

--- a/src/EdgeDB.Net.Driver/Models/Sendables/Terminate.cs
+++ b/src/EdgeDB.Net.Driver/Models/Sendables/Terminate.cs
@@ -8,7 +8,8 @@ namespace EdgeDB.Models
 {
     internal class Terminate : Sendable
     {
-        public override ClientMessageTypes Type => ClientMessageTypes.Terminate;
+        public override ClientMessageTypes Type 
+            => ClientMessageTypes.Terminate;
 
         protected override void BuildPacket(PacketWriter writer, EdgeDBBinaryClient client) { } // no data
     }

--- a/src/EdgeDB.Net.Driver/Models/Shared/Cardinality.cs
+++ b/src/EdgeDB.Net.Driver/Models/Shared/Cardinality.cs
@@ -30,6 +30,7 @@ namespace EdgeDB.Models
         ///     The command will return zero to infinite results.
         /// </summary>
         Many = 0x6d,
+
         /// <summary>
         ///     The command will return one to infinite results.
         /// </summary>

--- a/src/EdgeDB.Net.Driver/Models/Shared/ConnectionParam.cs
+++ b/src/EdgeDB.Net.Driver/Models/Shared/ConnectionParam.cs
@@ -9,6 +9,7 @@ namespace EdgeDB.Models
     internal struct ConnectionParam
     {
         public string Name { get; set; }
+
         public string Value { get; set; }
 
         public void Write(PacketWriter writer)

--- a/src/EdgeDB.Net.Driver/Serializer/ObjectBuilder.cs
+++ b/src/EdgeDB.Net.Driver/Serializer/ObjectBuilder.cs
@@ -11,7 +11,9 @@ namespace EdgeDB
         private struct EdgeDBPropertyInfo
         {
             public string EdgeDBName { get; set; }
+
             public PropertyInfo PropertyInfo { get; set; }
+
             public bool ShouldMakeSubType { get; set; }
         }
 
@@ -28,7 +30,7 @@ namespace EdgeDB
 
         public static object? BuildResult(Guid typeDescriptorId, Type targetType, object? raw)
         {
-            if (raw == null)
+            if (raw is null)
                 return null;
 
             if (targetType == typeof(object))
@@ -118,10 +120,10 @@ namespace EdgeDB
             {
                 var prop = properties.FirstOrDefault(x => x.EdgeDBName == result.Key);
 
-                if (prop.EdgeDBName != null)
+                if (prop.EdgeDBName is not null)
                 {
                     var other = objectProps.FirstOrDefault(x => x.Name == prop.PropertyInfo.Name);
-                    if (other != null)
+                    if (other is not null)
                     {
                         other.SetValue(instance, ConvertTo(typeDescriptorId, other.PropertyType, result.Value));
                     }
@@ -134,7 +136,7 @@ namespace EdgeDB
 
         private static bool ShouldCreateSubType(PropertyInfo info)
         {
-            if (info.PropertyType.Name == "ComputedValue`1")
+            if (info.PropertyType.Name is "ComputedValue`1")
                 return true;
 
             return false;
@@ -142,7 +144,7 @@ namespace EdgeDB
 
         private static object? ConvertTo(Guid descriptorId, Type type, object? value)
         {
-            if (value == null)
+            if (value is null)
             {
                 return ReflectionUtils.GetDefault(type);
             }
@@ -163,11 +165,11 @@ namespace EdgeDB
             }
 
             // check for computed values
-            if (type.Name == "ComputedValue`1" && type.GenericTypeArguments[0] == valueType)
+            if (type.Name is "ComputedValue`1" && type.GenericTypeArguments[0] == valueType)
             {
                 var method = type.GetRuntimeMethod("op_Implicit", new Type[] { valueType });
 
-                if (method != null)
+                if (method is not null)
                     return method.Invoke(null, new object[] { value });
             }
 
@@ -194,10 +196,10 @@ namespace EdgeDB
             {
                 if (val is IDictionary<string, object?> raw)
                 {
-                    converted.Add(strongInnerType != null ? BuildResult(descriptorId, strongInnerType, raw) : val);
+                    converted.Add(strongInnerType is not null ? BuildResult(descriptorId, strongInnerType, raw) : val);
                 }
                 else
-                    converted.Add(strongInnerType != null ? ConvertTo(descriptorId, strongInnerType, val) : val);
+                    converted.Add(strongInnerType is not null ? ConvertTo(descriptorId, strongInnerType, val) : val);
 
             }
 
@@ -227,9 +229,9 @@ namespace EdgeDB
 
         private static bool IsValidProperty(PropertyInfo type)
         {
-            var shouldIgnore = type.GetCustomAttribute<EdgeDBIgnoreAttribute>() != null;
+            var shouldIgnore = type.GetCustomAttribute<EdgeDBIgnoreAttribute>() is not null;
 
-            return !shouldIgnore && type.GetSetMethod() != null;
+            return !shouldIgnore && type.GetSetMethod() is not null;
         }
 
         private static bool IsValidTargetType(Type type) =>

--- a/src/EdgeDB.Net.Driver/Serializer/PacketReader.cs
+++ b/src/EdgeDB.Net.Driver/Serializer/PacketReader.cs
@@ -27,8 +27,8 @@ namespace EdgeDB
 
         public string ConsumeString()
         {
-            using (var streamReader = new StreamReader(base.BaseStream, Encoding.UTF8, leaveOpen: true))
-                return streamReader.ReadToEnd();
+            using var streamReader = new StreamReader(base.BaseStream, Encoding.UTF8, leaveOpen: true);
+            return streamReader.ReadToEnd();
         }
 
         public Guid ReadGuid()

--- a/src/EdgeDB.Net.Driver/Serializer/PacketSerializer.cs
+++ b/src/EdgeDB.Net.Driver/Serializer/PacketSerializer.cs
@@ -26,7 +26,7 @@ namespace EdgeDB
 
         public static string? GetEdgeQLType(Type t)
         {
-            if (t.Name == "Nullable`1")
+            if (t.Name is not "Nullable`1")
                 t = t.GenericTypeArguments[0];
             return _scalarTypeMap.TryGetValue(t, out var result) ? result : null;
         }
@@ -80,7 +80,7 @@ namespace EdgeDB
 
                 var codec = GetScalarCodec(typeDescriptor.Id);
 
-                if (codec != null)
+                if (codec is not null)
                     codecs.Add(codec);
                 else
                 {

--- a/src/EdgeDB.Net.Driver/Serializer/PacketWriter.cs
+++ b/src/EdgeDB.Net.Driver/Serializer/PacketWriter.cs
@@ -28,7 +28,7 @@ namespace EdgeDB
             // write length
             Write((ushort)(headers?.Count() ?? 0));
 
-            if(headers != null)
+            if(headers is not null)
             {
                 foreach (var header in headers)
                 {
@@ -60,7 +60,7 @@ namespace EdgeDB
 
         public override void Write(string value)
         {
-            if (value == null)
+            if (value is null)
                 Write((uint)0);
             else
             {

--- a/src/EdgeDB.Net.Driver/Utils/AsyncEvent.cs
+++ b/src/EdgeDB.Net.Driver/Utils/AsyncEvent.cs
@@ -17,6 +17,7 @@ namespace EdgeDB
 
         public void Add(T subscriber)
             => _subscriptions.TryAdd(subscriber.GetHashCode(), subscriber);
+
         public void Remove(T subscriber)
             => _subscriptions.TryRemove(subscriber.GetHashCode(), out _);
     }
@@ -48,24 +49,28 @@ namespace EdgeDB
             for (int i = 0; i < subscribers.Length; i++)
                 await subscribers[i].Invoke(arg).ConfigureAwait(false);
         }
+
         public static async ValueTask InvokeAsync<T1, T2>(this AsyncEvent<Func<T1, T2, ValueTask>> eventHandler, T1 arg1, T2 arg2)
         {
             var subscribers = eventHandler.Subscriptions;
             for (int i = 0; i < subscribers.Length; i++)
                 await subscribers[i].Invoke(arg1, arg2).ConfigureAwait(false);
         }
+
         public static async ValueTask InvokeAsync<T1, T2, T3>(this AsyncEvent<Func<T1, T2, T3, ValueTask>> eventHandler, T1 arg1, T2 arg2, T3 arg3)
         {
             var subscribers = eventHandler.Subscriptions;
             for (int i = 0; i < subscribers.Length; i++)
                 await subscribers[i].Invoke(arg1, arg2, arg3).ConfigureAwait(false);
         }
+
         public static async ValueTask InvokeAsync<T1, T2, T3, T4>(this AsyncEvent<Func<T1, T2, T3, T4, ValueTask>> eventHandler, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             var subscribers = eventHandler.Subscriptions;
             for (int i = 0; i < subscribers.Length; i++)
                 await subscribers[i].Invoke(arg1, arg2, arg3, arg4).ConfigureAwait(false);
         }
+
         public static async ValueTask InvokeAsync<T1, T2, T3, T4, T5>(this AsyncEvent<Func<T1, T2, T3, T4, T5, ValueTask>> eventHandler, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             var subscribers = eventHandler.Subscriptions;

--- a/src/EdgeDB.Net.Driver/Utils/ConfigUtils.cs
+++ b/src/EdgeDB.Net.Driver/Utils/ConfigUtils.cs
@@ -18,18 +18,16 @@ namespace EdgeDB.Utils
         private static string GetEdgeDBKnownBasePath()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
                 return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EdgeDB");
-            }
+
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
                 return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "edgedb");
-            }
+
             else
             {
                 var xdgConfigDir = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
 
-                if (xdgConfigDir == null || !Path.IsPathRooted(xdgConfigDir))
+                if (xdgConfigDir is null || !Path.IsPathRooted(xdgConfigDir))
                     xdgConfigDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config");
 
                 return Path.Combine(xdgConfigDir, "edgedb");
@@ -48,14 +46,10 @@ namespace EdgeDB.Utils
             string hash = "";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !fullPath.StartsWith("\\\\"))
-            {
                 fullPath = "\\\\?\\" + fullPath;
-            }
 
             using (var sha1 = SHA1.Create())
-            {
                 hash = HexConverter.ToHex(sha1.ComputeHash(Encoding.UTF8.GetBytes(fullPath)));
-            }
 
             return Path.Combine(GetEdgeDBBasePath(), "config", "projects", $"{baseName}-{hash.ToLower()}");
         }

--- a/src/EdgeDB.Net.Driver/Utils/HexConverter.cs
+++ b/src/EdgeDB.Net.Driver/Utils/HexConverter.cs
@@ -20,8 +20,6 @@ namespace EdgeDB.Utils
         }
 
         public static string ToHex(byte[] arr)
-        {
-            return BitConverter.ToString(arr).Replace("-", "");
-        }
+            => BitConverter.ToString(arr).Replace("-", "");
     }
 }

--- a/src/EdgeDB.Net.Driver/Utils/ReflectionUtils.cs
+++ b/src/EdgeDB.Net.Driver/Utils/ReflectionUtils.cs
@@ -15,7 +15,7 @@ namespace EdgeDB
 
         public static bool IsSubclassOfRawGeneric(Type generic, Type? toCheck)
         {
-            while (toCheck != null && toCheck != typeof(object))
+            while (toCheck is not null && toCheck != typeof(object))
             {
                 var cur = toCheck.IsGenericType ? toCheck.GetGenericTypeDefinition() : toCheck;
                 if (generic == cur)
@@ -31,7 +31,7 @@ namespace EdgeDB
         {
             genericReference = null;
 
-            while (toCheck != null && toCheck != typeof(object))
+            while (toCheck is not null && toCheck != typeof(object))
             {
                 var cur = toCheck.IsGenericType ? toCheck.GetGenericTypeDefinition() : toCheck;
                 if (generic == cur)
@@ -47,7 +47,7 @@ namespace EdgeDB
 
         public static TypeBuilder GetTypeBuilder(string name, TypeAttributes? attributes = null)
         {
-            if (ModuleBuilder == null)
+            if (ModuleBuilder is null)
             {
                 var assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("EdgeDB.Runtime")
                 {
@@ -108,12 +108,12 @@ namespace EdgeDB
             propertyBuilder.SetGetMethod(getPropMthdBldr);
             propertyBuilder.SetSetMethod(setPropMthdBldr);
 
-            if (overrideGetMethod != null)
+            if (overrideGetMethod is not null)
             {
                 tb.DefineMethodOverride(getPropMthdBldr, overrideGetMethod);
             }
 
-            if (overrideSetMethod != null)
+            if (overrideSetMethod is not null)
             {
                 tb.DefineMethodOverride(setPropMthdBldr, overrideSetMethod);
             }
@@ -129,7 +129,7 @@ namespace EdgeDB
                                                   Where(cInfo => longestCtor == null || longestCtor.GetParameters().Length < cInfo.GetParameters().Length))
                 longestCtor = cInfo;
 
-            if (longestCtor == null)
+            if (longestCtor is null)
             {
                 return null;
             }
@@ -140,7 +140,7 @@ namespace EdgeDB
             foreach (var consParamInfo in longestCtor.GetParameters())
             {
                 var attrPropInfo = customAttribute.GetType().GetProperty(consParamInfo.Name!, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-                if (attrPropInfo != null)
+                if (attrPropInfo is not null)
                 {
                     args[position] = attrPropInfo.GetValue(customAttribute, null);
                 }
@@ -148,7 +148,7 @@ namespace EdgeDB
                 {
                     args[position] = null;
                     var attrFieldInfo = customAttribute.GetType().GetField(consParamInfo.Name!, BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.IgnoreCase);
-                    if (attrFieldInfo == null)
+                    if (attrFieldInfo is null)
                     {
                         if (consParamInfo.ParameterType.IsValueType)
                         {

--- a/src/EdgeDB.Net.Driver/Utils/Scram.cs
+++ b/src/EdgeDB.Net.Driver/Utils/Scram.cs
@@ -105,10 +105,8 @@ namespace EdgeDB.Utils
 
         private static byte[] ComputeHMACHash(byte[] data, byte[] key)
         {
-            using (var hmac = new HMACSHA256(data))
-            {
-                return hmac.ComputeHash(key);
-            }
+            using var hmac = new HMACSHA256(data);
+            return hmac.ComputeHash(key);
         }
 
         private static byte[] GetClientKey(byte[] password)
@@ -127,10 +125,8 @@ namespace EdgeDB.Utils
 
         private static byte[] Hash(byte[] input)
         {
-            using (var hs = SHA256.Create())
-            {
-                return hs.ComputeHash(input);
-            }
+            using var hs = SHA256.Create();
+            return hs.ComputeHash(input);
         }
 
         private static byte[] XOR(byte[] b1, byte[] b2)

--- a/tools/EdgeDB.DotnetTool/Lexer/SchemaBuffer.cs
+++ b/tools/EdgeDB.DotnetTool/Lexer/SchemaBuffer.cs
@@ -9,7 +9,7 @@ namespace EdgeDB.DotnetTool.Lexer
 {
     internal class SchemaBuffer
     {
-        string _buffer;
+        readonly string _buffer;
         int _bufferPos;
 
         public int Column { get; private set; }
@@ -81,7 +81,7 @@ namespace EdgeDB.DotnetTool.Lexer
             int index = portion.LastIndexOf('\n');
             if (index >= 0)
             {
-                Column = new StringInfo(portion.Substring(index + 1)).LengthInTextElements + 1;
+                Column = new StringInfo(portion[(index + 1)..]).LengthInTextElements + 1;
                 Line += portion.Count((ch) => ch == '\n');
             }
             else

--- a/tools/EdgeDB.DotnetTool/Lexer/Token.cs
+++ b/tools/EdgeDB.DotnetTool/Lexer/Token.cs
@@ -9,10 +9,15 @@ namespace EdgeDB.DotnetTool.Lexer
     internal class Token
     {
         public TokenType Type { get; set; }
+
         public string? Value { get; set; }
+
         public int StartPos { get; set; }
+
         public int StartLine { get; set; }
+
         public int EndPos { get; set; }
+
         public int EndLine { get; set; }
     }
 }

--- a/tools/EdgeDB.DotnetTool/Program.cs
+++ b/tools/EdgeDB.DotnetTool/Program.cs
@@ -2,6 +2,6 @@
 using EdgeDB.DotnetTool;
 using System.Reflection;
 
-var commands = Assembly.GetExecutingAssembly().GetTypes().Where(x => x.GetInterfaces().Any(x => x == typeof(ICommand)));
+var commands = typeof(Program).Assembly.GetTypes().Where(x => x.GetInterfaces().Any(x => x == typeof(ICommand)));
 
 Parser.Default.ParseArguments(args, commands.ToArray()).WithParsed<ICommand>(t => t.Execute());

--- a/tools/EdgeDB.DotnetTool/Schemas/ClassBuilderContext.cs
+++ b/tools/EdgeDB.DotnetTool/Schemas/ClassBuilderContext.cs
@@ -9,13 +9,17 @@ namespace EdgeDB.DotnetTool
     internal class ClassBuilderContext
     {
         public List<Type> BuiltTypes { get; set; } = new();
+
         public List<Property> BuildProperties { get; set; } = new();
+
         public Func<string, string> NameCallback { get; set; } = (s) => s;
 
         public List<string> RequestedAttributes { get; set; } = new();
 
         public Type? Type { get; set; }
+
         public Module? Module { get; set; }
+
         public Property? Property { get; set; }
 
         public string? OutputDir { get; set; }

--- a/tools/EdgeDB.DotnetTool/Schemas/Models/Annotation.cs
+++ b/tools/EdgeDB.DotnetTool/Schemas/Models/Annotation.cs
@@ -9,7 +9,9 @@ namespace EdgeDB.DotnetTool
     internal class Annotation
     {
         public string? Title { get; set; }
+
         public string? Description { get; set; }
+
         public string? Deprecated { get; set; }
     }
 }

--- a/tools/EdgeDB.DotnetTool/Schemas/Models/Constraint.cs
+++ b/tools/EdgeDB.DotnetTool/Schemas/Models/Constraint.cs
@@ -9,6 +9,7 @@ namespace EdgeDB.DotnetTool
     internal class Constraint
     {
         public string? Value { get; set; }
+
         public bool IsExpression { get; set; }
     }
 }

--- a/tools/EdgeDB.DotnetTool/Schemas/Models/Module.cs
+++ b/tools/EdgeDB.DotnetTool/Schemas/Models/Module.cs
@@ -9,6 +9,7 @@ namespace EdgeDB.DotnetTool
     internal class Module
     {
         public string? Name { get; set; }
+
         public List<Type> Types { get; set; } = new();
     }
 }

--- a/tools/EdgeDB.DotnetTool/Schemas/Models/Property.cs
+++ b/tools/EdgeDB.DotnetTool/Schemas/Models/Property.cs
@@ -5,19 +5,31 @@
         public Type? Parent { get; set; }
 
         public string? Name { get; set; }
+
         public string? Type { get; set; }
+
         public bool Required { get; set; }
+
         public PropertyCardinality Cardinality { get; set; }
+
         public string? DefaultValue { get; set; }
+
         public bool ReadOnly { get; set; }
+
         public List<Constraint> Constraints { get; set; } = new();
+
         public Annotation? Annotation { get; set; }
+
         public List<Property> LinkProperties { get; set; } = new();
 
         public bool IsStrictlyConstraint { get; set; }
+
         public bool IsAbstract { get; set; }
+
         public bool IsLink { get; set; }
+
         public bool IsComputed { get; set; }
+
         public string? ComputedValue { get; set; }
 
         public string? Extending { get; set; }

--- a/tools/EdgeDB.DotnetTool/Schemas/Models/Type.cs
+++ b/tools/EdgeDB.DotnetTool/Schemas/Models/Type.cs
@@ -11,10 +11,15 @@ namespace EdgeDB.DotnetTool
         public Module? Parent { get; set; }
 
         public string? Name { get; set; }
+
         public string? Extending { get; set; }
+
         public bool IsAbstract { get; set; }
+
         public bool IsScalar { get; set; }
+
         public bool IsLink { get; set; }
+
         public List<Property> Properties { get; set; } = new();
 
         // used for builder

--- a/tools/EdgeDB.DotnetTool/Schemas/SchemaReader.cs
+++ b/tools/EdgeDB.DotnetTool/Schemas/SchemaReader.cs
@@ -8,7 +8,7 @@ namespace EdgeDB.DotnetTool
 
         public SchemaReader(string schema)
         {
-            _lexer = new SchemaLexer(schema);
+            _lexer = new(schema);
         }
 
         public List<Module> Read()

--- a/tools/EdgeDB.DotnetTool/Util/CodeWriter.cs
+++ b/tools/EdgeDB.DotnetTool/Util/CodeWriter.cs
@@ -9,6 +9,7 @@ namespace EdgeDB.DotnetTool
 	internal class CodeWriter
 	{
 		public readonly StringBuilder Content = new();
+
 		public int IndentLevel { get; private set; }
 
 		private readonly ScopeTracker _scopeTracker; //We only need one. It can be reused.
@@ -18,15 +19,21 @@ namespace EdgeDB.DotnetTool
 			_scopeTracker = new(this); //We only need one. It can be reused.
 		}
 
-		public void Append(string line) => Content.Append(line);
-		public void AppendLine(string line) => Content.Append(new string(' ', IndentLevel)).AppendLine(line);
-		public void AppendLine() => Content.AppendLine();
+		public void Append(string line) 
+			=> Content.Append(line);
+
+		public void AppendLine(string line) 
+			=> Content.Append(new string(' ', IndentLevel)).AppendLine(line);
+
+		public void AppendLine() 
+			=> Content.AppendLine();
 
 		public IDisposable BeginScope(string line)
 		{
 			AppendLine(line);
 			return BeginScope();
 		}
+
 		public IDisposable BeginScope()
 		{
 			Content.Append(new string(' ', IndentLevel)).AppendLine("{");
@@ -42,8 +49,11 @@ namespace EdgeDB.DotnetTool
 			Content.Append(new string(' ', IndentLevel)).AppendLine("}");
 		}
 
-		public void StartLine() => Content.Append(new string(' ', IndentLevel));
-		public override string ToString() => Content.ToString();
+		public void StartLine() 
+			=> Content.Append(new string(' ', IndentLevel));
+
+		public override string ToString() 
+			=> Content.ToString();
 
 		class ScopeTracker : IDisposable
 		{
@@ -51,6 +61,7 @@ namespace EdgeDB.DotnetTool
 			{
 				Parent = parent;
 			}
+
 			public CodeWriter Parent { get; }
 
 			public void Dispose()

--- a/tools/EdgeDB.DotnetTool/Util/PascalUtils.cs
+++ b/tools/EdgeDB.DotnetTool/Util/PascalUtils.cs
@@ -7,32 +7,37 @@ using System.Threading.Tasks;
 
 namespace EdgeDB.DotnetTool
 {
-    internal class PascalUtils
+    internal static class PascalUtils
     {
+        readonly static Regex _invalidCharsRgx = new("[^_a-zA-Z0-9]", RegexOptions.Compiled);
+
+        readonly static Regex _whiteSpace = new(@"(?<=\s)", RegexOptions.Compiled);
+
+        readonly static Regex _startsWithLowerCaseChar = new("^[a-z]", RegexOptions.Compiled);
+
+        readonly static Regex _firstCharFollowedByUpperCasesOnly = new("(?<=[A-Z])[A-Z0-9]+$", RegexOptions.Compiled);
+
+        readonly static Regex _lowerCaseNextToNumber = new("(?<=[0-9])[a-z]", RegexOptions.Compiled);
+
+        readonly static Regex _upperCaseInside = new("(?<=[A-Z])[A-Z]+?((?=[A-Z][a-z])|(?=[0-9]))", RegexOptions.Compiled);
+
         public static string ToPascalCase(string? original)
         {
             if (original == null)
                 return "";
 
-            Regex invalidCharsRgx = new Regex("[^_a-zA-Z0-9]");
-            Regex whiteSpace = new Regex(@"(?<=\s)");
-            Regex startsWithLowerCaseChar = new Regex("^[a-z]");
-            Regex firstCharFollowedByUpperCasesOnly = new Regex("(?<=[A-Z])[A-Z0-9]+$");
-            Regex lowerCaseNextToNumber = new Regex("(?<=[0-9])[a-z]");
-            Regex upperCaseInside = new Regex("(?<=[A-Z])[A-Z]+?((?=[A-Z][a-z])|(?=[0-9]))");
-
             // replace white spaces with undescore, then replace all invalid chars with empty string
-            var pascalCase = invalidCharsRgx.Replace(whiteSpace.Replace(original, "_"), string.Empty)
+            var pascalCase = _invalidCharsRgx.Replace(_whiteSpace.Replace(original, "_"), string.Empty)
                 // split by underscores
                 .Split(new char[] { '_' }, StringSplitOptions.RemoveEmptyEntries)
                 // set first letter to uppercase
-                .Select(w => startsWithLowerCaseChar.Replace(w, m => m.Value.ToUpper()))
+                .Select(w => _startsWithLowerCaseChar.Replace(w, m => m.Value.ToUpper()))
                 // replace second and all following upper case letters to lower if there is no next lower (ABC -> Abc)
-                .Select(w => firstCharFollowedByUpperCasesOnly.Replace(w, m => m.Value.ToLower()))
+                .Select(w => _firstCharFollowedByUpperCasesOnly.Replace(w, m => m.Value.ToLower()))
                 // set upper case the first lower case following a number (Ab9cd -> Ab9Cd)
-                .Select(w => lowerCaseNextToNumber.Replace(w, m => m.Value.ToUpper()))
+                .Select(w => _lowerCaseNextToNumber.Replace(w, m => m.Value.ToUpper()))
                 // lower second and next upper case letters except the last if it follows by any lower (ABcDEf -> AbcDef)
-                .Select(w => upperCaseInside.Replace(w, m => m.Value.ToLower()));
+                .Select(w => _upperCaseInside.Replace(w, m => m.Value.ToLower()));
 
             return string.Concat(pascalCase);
         }

--- a/tools/EdgeDB.QueryBuilder.OperatorGenerator/Models/EdgeQLFunction.cs
+++ b/tools/EdgeDB.QueryBuilder.OperatorGenerator/Models/EdgeQLFunction.cs
@@ -7,8 +7,11 @@ namespace EdgeDB.QueryBuilder.OperatorGenerator
     public class EdgeQLFunction
     {
         public string? Name { get; set; }
+
         public List<string> Parameters { get; set; } = new();
+
         public string? Return { get; set; }
+
         public string? Filter { get; set; }
     }
 }

--- a/tools/EdgeDB.QueryBuilder.OperatorGenerator/Models/EdgeQLOperator.cs
+++ b/tools/EdgeDB.QueryBuilder.OperatorGenerator/Models/EdgeQLOperator.cs
@@ -7,18 +7,24 @@ namespace EdgeDB.QueryBuilder.OperatorGenerator
     public class EdgeQLOperator
     {
         public string? Expression { get; set; }
+
         public string? Operator { get; set; }
+
         public string? Return { get; set; }
+
         public string? Name { get; set; }
+
         public List<EdgeQLFunction>? Functions { get; set; } = new();
+
         public List<string> ParameterMap { get; set; } = new();
 
         public List<string> PropertyMap { get; set; } = new();
-        public List<string> FunctionMap { get; set; } = new();
 
+        public List<string> FunctionMap { get; set; } = new();
 
         // enum
         public List<string> Elements { get; set; } = new();
+
         public string? SerializeMethod { get; set; }
     }
 }

--- a/tools/EdgeDB.QueryBuilder.OperatorGenerator/Util/CodeWriter.cs
+++ b/tools/EdgeDB.QueryBuilder.OperatorGenerator/Util/CodeWriter.cs
@@ -16,15 +16,21 @@ namespace EdgeDB.QueryBuilder.OperatorGenerator
 			_scopeTracker = new(this); //We only need one. It can be reused.
 		}
 
-		public void Append(string line) => Content.Append(line);
-		public void AppendLine(string line) => Content.Append(new string(' ', IndentLevel)).AppendLine(line);
-		public void AppendLine() => Content.AppendLine();
+		public void Append(string line) 
+			=> Content.Append(line);
+
+		public void AppendLine(string line) 
+			=> Content.Append(new string(' ', IndentLevel)).AppendLine(line);
+
+		public void AppendLine() 
+			=> Content.AppendLine();
 
 		public IDisposable BeginScope(string line)
 		{
 			AppendLine(line);
 			return BeginScope();
 		}
+
 		public IDisposable BeginScope()
 		{
 			Content.Append(new string(' ', IndentLevel)).AppendLine("{");
@@ -32,7 +38,8 @@ namespace EdgeDB.QueryBuilder.OperatorGenerator
 			return _scopeTracker;
 		}
 
-		public void EndLine() => Content.AppendLine();
+		public void EndLine() 
+			=> Content.AppendLine();
 
 		public void EndScope()
 		{
@@ -40,8 +47,11 @@ namespace EdgeDB.QueryBuilder.OperatorGenerator
 			Content.Append(new string(' ', IndentLevel)).AppendLine("}");
 		}
 
-		public void StartLine() => Content.Append(new string(' ', IndentLevel));
-		public override string ToString() => Content.ToString();
+		public void StartLine() 
+			=> Content.Append(new string(' ', IndentLevel));
+
+		public override string ToString() 
+			=> Content.ToString();
 
 		class ScopeTracker : IDisposable
 		{


### PR DESCRIPTION
- Swaps `==` & `!=` for `is` and `is not` for constants as this has a noticable performance boost.
- Newlines all `=>` getters.
- Adds spacing between all properties.
- Some other funny stuff

> Ran through all the code to get an idea of the logic. 