### PR TITLE
Fix PacketWriter.Write(string) method

### DIFF
--- a/src/EdgeDB.Net.Driver/Serializer/PacketWriter.cs
+++ b/src/EdgeDB.Net.Driver/Serializer/PacketWriter.cs
@@ -64,8 +64,9 @@ namespace EdgeDB
                 Write((uint)0);
             else
             {
-                Write((uint)value.Length);
-                Write(Encoding.UTF8.GetBytes(value));
+                var buffer = Encoding.UTF8.GetBytes(value);
+                Write((uint)buffer.Length);
+                Write(buffer);
             }
 
         }


### PR DESCRIPTION
Use correct buffer length instead of string length. It's important, when you use multi-byte UTF-8 characters in commands.