### PR TITLE
feature: client pool management

### DIFF
--- a/src/EdgeDB.Net.Driver/Clients/BaseEdgeDBClient.cs
+++ b/src/EdgeDB.Net.Driver/Clients/BaseEdgeDBClient.cs
@@ -23,6 +23,14 @@
         }
 
         private readonly AsyncEvent<Func<BaseEdgeDBClient, ValueTask<bool>>> _onDisposed = new();
+
+        internal event Func<BaseEdgeDBClient, ValueTask> OnDisconnect
+        {
+            add => OnDisconnectInternal.Add(value);
+            remove => OnDisconnectInternal.Remove(value);
+        }
+
+        internal readonly AsyncEvent<Func<BaseEdgeDBClient, ValueTask>> OnDisconnectInternal = new();
         /// <summary>
         ///     Initialized the base client.
         /// </summary>
@@ -59,10 +67,15 @@
         /// <summary>
         ///     Disconnects this client from the database.
         /// </summary>
+        /// <remarks>
+        ///     When overridden, it's <b>strongly</b> recommended to call base.DisconnectAsync
+        ///     to ensure the client pool removes this client.
+        /// </remarks>
         /// <returns>
         ///     A ValueTask representing the asynchronous disconnect operation.
         /// </returns>
-        public abstract ValueTask DisconnectAsync();
+        public virtual ValueTask DisconnectAsync()
+            => OnDisconnectInternal.InvokeAsync(this);
 
         /// <summary>
         ///     Connects this client to the database.

--- a/src/EdgeDB.Net.Driver/Clients/EdgeDBBinaryClient.cs
+++ b/src/EdgeDB.Net.Driver/Clients/EdgeDBBinaryClient.cs
@@ -39,10 +39,10 @@ namespace EdgeDB
         /// <summary>
         ///     Fired when the client disconnects.
         /// </summary>
-        public event Func<ValueTask> OnDisconnect
+        public new event Func<ValueTask> OnDisconnect
         {
-            add => _onDisconnect.Add(value);
-            remove => _onDisconnect.Remove(value);
+            add => OnDisconnectInternal.Add((c) => value());
+            remove => OnDisconnectInternal.Remove((c) => value());
         }
 
         /// <summary>
@@ -73,7 +73,6 @@ namespace EdgeDB
         internal readonly TimeSpan ConnectionTimeout;
         internal readonly EdgeDBConnection Connection;
 
-        private readonly AsyncEvent<Func<ValueTask>> _onDisconnect = new();
         private readonly AsyncEvent<Func<IReceiveable, ValueTask>> _onMessage = new();
         private readonly AsyncEvent<Func<ExecuteResult, ValueTask>> _queryExecuted = new();
 


### PR DESCRIPTION
## Summary
This PR adds a `DisconnectAllAsync` method to the client pool that, you guessed it, disconnects all clients that are currently connected.

On top of that this PR also exposes a few properties on the client pool to help users get insights about the client pool.

Closes #4 