### PR TITLE
Add client side type converters

### DIFF
--- a/examples/EdgeDB.Examples.CSharp/Examples/CustomTypeConverters.cs
+++ b/examples/EdgeDB.Examples.CSharp/Examples/CustomTypeConverters.cs
@@ -1,0 +1,44 @@
+using EdgeDB.TypeConverters;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.ExampleApp.Examples
+{
+    internal class CustomTypeConverters : IExample
+    {
+        public ILogger? Logger { get; set; }
+
+        public class UserWithSnowflakeId
+        {
+            public ulong UserId { get; set; }
+            public string? Username { get; set; }
+        }
+
+        public class UlongTypeConverter : EdgeDBTypeConverter<ulong, string>
+        {
+            public override ulong ConvertFrom(string? value)
+            {
+                if (value is null)
+                    return 0;
+
+                return ulong.Parse(value);
+            }
+            
+            public override string? ConvertTo(ulong value)
+            {
+                return value.ToString();
+            }
+        }
+
+        public async Task ExecuteAsync(EdgeDBClient client)
+        {
+            var user = await client.QueryAsync<UserWithSnowflakeId>("with u := (insert UserWithSnowflakeId { user_id := \"841451783728529451\", username := \"example\" } unless conflict on .user_id else (select UserWithSnowflakeId)) select u { user_id, username }");
+
+            Logger!.LogInformation("User with snowflake id: {@User}", user);
+        }
+    }
+}

--- a/src/EdgeDB.Net.Driver/Attributes/EdgeDBTypeConverterAttribute.cs
+++ b/src/EdgeDB.Net.Driver/Attributes/EdgeDBTypeConverterAttribute.cs
@@ -1,0 +1,30 @@
+using EdgeDB.TypeConverters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class EdgeDBTypeConverterAttribute : Attribute
+    {
+        internal IEdgeDBTypeConverter Converter;
+
+        public EdgeDBTypeConverterAttribute(Type converterType)
+        {
+            if (converterType.GetInterface(nameof(IEdgeDBTypeConverter)) is null)
+            {
+                throw new ArgumentException("Converter type must implement IEdgeDBTypeConverter");
+            }
+
+            if (converterType.IsAbstract || converterType.IsInterface)
+            {
+                throw new ArgumentException("Converter type must be a concrete type");
+            }
+
+            Converter = (IEdgeDBTypeConverter)Activator.CreateInstance(converterType)!;
+        }
+    }
+}

--- a/src/EdgeDB.Net.Driver/Binary/Builders/TypeConverters/EdgeDBTypeConverter.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Builders/TypeConverters/EdgeDBTypeConverter.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.TypeConverters
+{
+    /// <summary>
+    ///     Represents a generic client-side type converter.
+    /// </summary>
+    /// <typeparam name="TSource">The client-side type which the converter is responsible for converting.</typeparam>
+    /// <typeparam name="TTarget">The database-side type which the converter is responsible for converting to.</typeparam>
+    public abstract class EdgeDBTypeConverter<TSource, TTarget> : IEdgeDBTypeConverter
+    {
+        /// <summary>
+        ///     Converts the given <typeparamref name="TTarget"/> to a <typeparamref name="TSource"/>.
+        /// </summary>
+        /// <param name="value">The value to convert to a <typeparamref name="TSource"/>.</param>
+        /// <returns>
+        ///     An instance of <typeparamref name="TSource"/>; or <see langword="default"/>.
+        /// </returns>
+        public abstract TSource? ConvertFrom(TTarget? value);
+
+        /// <summary>
+        ///     Converts the given <typeparamref name="TSource"/> to a <typeparamref name="TTarget"/>.
+        /// </summary>
+        /// <param name="value">The value to convert to a <typeparamref name="TTarget"/>.</param>
+        /// <returns>An instance of <typeparamref name="TTarget"/>; or <see langword="default"/>.</returns>
+        public abstract TTarget? ConvertTo(TSource? value);
+
+        object? IEdgeDBTypeConverter.ConvertFrom(object? value)
+            => ConvertFrom((TTarget?)value);
+        object? IEdgeDBTypeConverter.ConvertTo(object? value)
+            => ConvertTo((TSource?)value);
+        bool IEdgeDBTypeConverter.CanConvert(System.Type from, System.Type to)
+            => from == typeof(TSource) && to == typeof(TTarget);
+    }
+
+    internal interface IEdgeDBTypeConverter
+    {
+        object? ConvertFrom(object? value);
+        object? ConvertTo(object? value);
+
+        bool CanConvert(Type from, Type to);
+    }
+}

--- a/src/EdgeDB.Net.Driver/Binary/Codecs/Object.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Codecs/Object.cs
@@ -68,7 +68,7 @@ namespace EdgeDB.Binary.Codecs
                         if (!deserializerInfo.PropertyMap.TryGetValue(_propertyNames[i], out var propInfo))
                             throw new EdgeDBException($"Property {_propertyNames[i]} not found on type {target.Name}");
 
-                        objCodec.Initialize(propInfo.PropertyType);
+                        objCodec.Initialize(propInfo.Type);
                     }
                 }
 


### PR DESCRIPTION
## Summary
This PR implements client side type converters as outlined in #31.

### Remarks
- The attribute and class name was changed from `EdgeDBConverter`  to `EdgeDBTypeConverter`.
- The converter base class is available under the new namespace `EdgeDB.TypeConverters`.

### Things to look into
- Should there be a set of default type converters? ex `ulong` -> `string` that will implicitly convert one type to another? This feature is sort of implemented with the `Convert.ChangeType` fallback within the object builder but there is no serialization side for this behavior.

Closes #31

**Footnote**
PR was remade since git kinda died trying to load the diff correctly.